### PR TITLE
Added support for postgres sslmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Simple mongo connexion test
 }
 ```
 
-### Postgresql connexion test
+### Postgresql connection test
 
-Simple postgresql connexion test
+Simple postgresql connection test
 
 ```json
 {
@@ -43,6 +43,7 @@ Simple postgresql connexion test
     "database": "database",
     "ip": "localhost",
     "port": "5432",
+    "sslmode": "require",
     "statusCakeUrl": "https://push.statuscake.com/?PK=PK&TestID=TestID&time=0"
 }
 ```

--- a/testsSample.json
+++ b/testsSample.json
@@ -26,6 +26,7 @@
 			"database": "database",
 			"ip": "localhost",
 			"port": "5432",
+			"sslmode": "require",
 			"statusCakeUrl": "https://push.statuscake.com/?PK=PK&TestID=TestID&time=0"
 		},
 		{

--- a/tools.py
+++ b/tools.py
@@ -127,7 +127,8 @@ def testPostgresql(test):
             database=test['database'],
             port=test['port'],
             user=test['user'],
-            password=test['password']
+            password=test['password'],
+            sslmode=test['sslmode']
         )
         conn.close()
         pingStatusCake(test['statusCakeUrl'])


### PR DESCRIPTION
Without this change, the scripts cannot be used to test connectivity to a postgres instance that is using ssl as the connection will fail.

This change adds sslmode to the postgres test configuration and passes the parameter to the postgres library.